### PR TITLE
 Fix : 유저 생성 시 type 필드 enum값 갖도록 버그 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ enum story_content_type {
 enum user_type {
   category_user
   memo_user
+  null
 }
 
 model User {

--- a/src/auth.config.js
+++ b/src/auth.config.js
@@ -24,7 +24,7 @@ const verify = async (profile, email, platform) => {
             platform,
             name: profile.displayName,
             nickname: "추후 수정",
-            type: null,
+            type: "null",
             introduction: "추후 수정",
             link: "추후 수정",
         },


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

유저 생성할때 type 값이 null을 갖도록 설정했었는데, DB에서 enum 타입은 null값을 가질 수 없음 .
type필드의 enum에 "null"을 추가한 후, 유저가 생성될때 "null"을 가지도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
단순 작업이라 오늘안에 merge하겠습니다 