### PR TITLE
Test : 테스트용 유저 생성 API 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -338,7 +338,7 @@ model Session {
 
 model RefreshToken {
   id        String   @id @default(uuid())
-  userId    String   @unique
+  userId    BigInt   @unique
   token     String   @unique
   expiresAt DateTime @map("expires_at")
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import { userDeleteScheduler } from "./scheduler.js";
 import { upload } from "./multer.js";
 import { authenticateJWT } from "./auth.config.js";
 import { handleNaverTokenLogin, handleKakaoTokenLogin, handleGoogleTokenLogin } from "./auth.config.js";
-
+import { testUserMiddleware } from "./test.js";
 
 dotenv.config();
 
@@ -115,7 +115,7 @@ app.get("/openapi.json", async (req, res, next) => {
           type: "http",
           scheme: "bearer",
           bearerFormat: "JWT",
-          description: "Authorization 헤더에 'Bearer {token}' 형식으로 입력하세요."
+          description: "토큰을 입력하세요."
         }
       }
     },
@@ -216,6 +216,8 @@ app.post("/oauth2/google/token", handleGoogleTokenLogin);
 //리프레시 토큰 이용해 액세스 토큰 재발급 
 app.post("/refresh_token", handleRefreshToken);
 
+//테스트용 (로컬 DB에 유저 추가 및 토큰 발급)
+app.post("/test/create_user", testUserMiddleware);
 
 // Mock 인증 미들웨어
 const mockAuthMiddleware = (req, res, next) => {

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,91 @@
+import { generateTokens } from "./auth.config.js";
+import { prisma } from "./db.config.js"
+
+export const testUserMiddleware = async (req, res, next) => {
+    /*
+        #swagger.summary = "로컬 테스트용 유저 생성 및 JWT 발급"
+        #swagger.description = "이 API는 로컬 테스트 환경에서 사용할 유저를 데이터베이스에 추가하고, JWT 토큰을 발급합니다."
+        #swagger.tags = ["Local Test"]
+
+        #swagger.responses[200] = {
+            description: "테스트 유저 생성 성공 응답",
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            resultType: { type: "string", example: "SUCCESS" },
+                            success: {
+                                type: "object",
+                                properties: {
+                                    accessToken: { type: "string", example: "abc123.jwt.token" },
+                                    refreshToken: { type: "string", example: "xyz456.jwt.token" },
+                                    user: {
+                                        type: "object",
+                                        properties: {
+                                            id: { type: "integer", example: 1 },
+                                            email: { type: "string", example: "planalog@naver.com" },
+                                            platform: { type: "string", example: "naver" },
+                                            name: { type: "string", example: "유엠씨" },
+                                            type: { type: "string", example: "category_user" },
+                                            nickname: { type: "string", example: "플라니" },
+                                            introduction: { type: "string", example: "추후 수정" },
+                                            link: { type: "string", example: "추후 수정" },
+                                            createdAt: { type: "string", format: "date-time", example: "2025-01-30T12:34:56.789Z" },
+                                            updatedAt: { type: "string", format: "date-time", example: "2025-01-30T12:34:56.789Z" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    */
+    try {
+        const testUserData = {
+            email: "planalog@naver.com",
+            platform: "naver",
+            name: "유엠씨",
+            nickname: "플라니",
+            type: "category_user",
+            introduction: "추후 수정",
+            link: "추후 수정",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+
+        // DB에 테스트 유저 추가 (이미 있으면 추가 안 함)
+        let user = await prisma.user.findUnique({ where: { email: testUserData.email } });
+
+        if (!user) {
+            user = await prisma.user.create({ data: testUserData });
+        }
+
+        // JWT 토큰 생성
+        const { accessToken, refreshToken } = generateTokens(user);
+
+        // 리프레시 토큰 저장
+        await prisma.refreshToken.create({
+            data: {
+                userId: user.id,
+                token: refreshToken,
+                expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7일 후 만료
+            },
+        });
+
+        return res.json({
+            resultType: "SUCCESS",
+            success: {
+                accessToken,
+                refreshToken,
+                user,
+            },
+        });
+
+    } catch (error) {
+        console.error("테스트 유저 생성 오류:", error);
+        return res.status(500).json({ message: "테스트 유저 생성 실패", error: error.message });
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

로컬에서 테스트할떄 소셜로그인이 불가능해졌으므로 (프론트에서 넘겨주는 액세스토큰이 필요함),  로컬 테스트용 유저를 생성하는 API를 추가했습니다! 

![image](https://github.com/user-attachments/assets/cbe42957-23ab-4d1b-99bc-6ffa19357813)

스웨거에서 이 API 로 요청을 보내주시면, 로컬 DB에 테스트용 유저가 저장되고 JWT토큰이 발급됩니다! 

![image](https://github.com/user-attachments/assets/760fd437-50b3-41a9-9940-cdaf7bf54459)

성공응답에서 액세스 토큰을 복사해주시면 됩니다 

![image](https://github.com/user-attachments/assets/5b653947-6cb6-4953-924b-087b8537944d)

스웨거의 Authorize 에 복사한 토큰값을 붙여넣기 해주세요.

![image](https://github.com/user-attachments/assets/8917f978-b426-4dc4-b35e-868bd057e3e7)

이 상태에서 다른 API 테스트 하시면 정상적으로 토큰 적용하여 테스트 가능합니다!

토큰이 필요한 API 요청의 스웨거 주석에 아래 코드를 추가해주세요. 

```
/*
#swagger.security = [{
        "bearerAuth": []
    }]
*/
```

아래 사진처럼 해당 API 오른쪽에 자물쇠모양이 생기고, 요청할 때 토큰이 자동으로 추가됩니다! 

![image](https://github.com/user-attachments/assets/f12f57e8-cffb-4af6-9e72-2670db56689b)

액세스토큰 만료시 리프레시토큰으로 액세스토큰 재발급하는 API이용해주세요. 리프레시토큰은 DB에도 저장되어있습니다!


