### PR TITLE
Feature : 소셜로그인 시 프론트가 소셜리프레시토큰도 넘겨주도록 수정 + user에 SocialRefreshToken …

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,15 +42,16 @@ model User {
   platform platform_type? // ENUM: kakao google naver 
   name     String         @db.VarChar(30)
 
-  nickname     String    @db.VarChar(20)
-  type         user_type // ENUM: memo or category 
-  introduction String?   @db.VarChar(300)
-  link         String?   @db.VarChar(100)
-  profileImage String?   @map("profile_image") @db.Text
-  isDeleted    Boolean   @default(false) @map("is_deleted")
-  deletedAt    DateTime? @map("deleted_at")
-  createdAt    DateTime  @default(now()) @map("created_at")
-  updatedAt    DateTime  @updatedAt @map("updated_at")
+  nickname           String    @db.VarChar(20)
+  type               user_type // ENUM: memo or category 
+  introduction       String?   @db.VarChar(300)
+  link               String?   @db.VarChar(100)
+  profileImage       String?   @map("profile_image") @db.Text
+  isDeleted          Boolean   @default(false) @map("is_deleted")
+  deletedAt          DateTime? @map("deleted_at")
+  createdAt          DateTime  @default(now()) @map("created_at")
+  updatedAt          DateTime  @updatedAt @map("updated_at")
+  socialRefreshToken String?   @map("social_refresh_token")
 
   // Relationships
   planners       Planner[]


### PR DESCRIPTION


## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 수정이 필요한 이유 

회원탈퇴를 하려면 소셜서버(네이버, 카카오,구글)에 소셜리프레시토큰을 이용해 연결끊기 요청을 보내야합니다.
 기존 로그인 API에서는 프론트에게 소셜액세스토큰만 전달받아 회원가입/로그인을 진행했었는데, 회원탈퇴를 위해서는 소셜리프레시토큰을 함께 받아 DB에 저장해놓고, 회원탈퇴 시에 그 리프레시토큰을 사용해야합니다! 

- 수정사항 

소셜로그인시 프론트로부터 리프레시토큰도 함께 받도록 수정하였습니다
User 테이블에 socialRefreshToken이라는 애트리뷰트를 추가하였습니다.

- 팀원 요구사항

프리즈마 모델 변경사항을 DB에 꼭 반영해주세요 (migrate나 push 이용)

