### PR TITLE
Refactor: moment생성api의 status필드 수정, 에러추가, momentContent로직 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,11 +24,12 @@ enum like_type {
   moment
 }
 
-enum share_status {
-  public
-  friend
-  draft
-}
+/**
+ * enum share_status {
+ * public
+ * draft
+ * }
+ */
 
 enum user_type {
   category_user
@@ -219,16 +220,15 @@ model Avatar {
 }
 
 model Moment {
-  id           BigInt       @id @default(autoincrement())
-  userId       BigInt       @map("user_id")
-  title        String       @db.VarChar(100)
-  status       share_status @map("status") // ENUM (public, friend, draft)
-  plannerId    BigInt?      @map("planner_id")
-  likingCount  BigInt       @default(0) @map("liking_count")
-  commentCount BigInt       @default(0) @map("comment_count")
-  publishedAt  DateTime?    @map("published_at")
-  createdAt    DateTime     @default(now()) @map("created_at")
-  updatedAt    DateTime     @updatedAt @map("updated_at")
+  id           BigInt   @id @default(autoincrement())
+  userId       BigInt   @map("user_id")
+  title        String   @db.VarChar(100)
+  //status       share_status @map("status") // ENUM (public, draft)
+  plannerId    BigInt?  @map("planner_id")
+  likingCount  BigInt   @default(0) @map("liking_count")
+  commentCount BigInt   @default(0) @map("comment_count")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   // Relationships
   user           User            @relation(fields: [userId], references: [id])
@@ -243,7 +243,7 @@ model Moment {
 model MomentContent {
   id        BigInt  @id @default(autoincrement())
   momentId  BigInt  @map("moment_id")
-  sortOrder Int     @map("sort_order") // 페이지 순서 
+  sortOrder BigInt  @map("sort_order") // 페이지 순서 
   content   String  @db.Text
   url       String? @db.VarChar(300)
 

--- a/src/controllers/moment.controller.js
+++ b/src/controllers/moment.controller.js
@@ -14,53 +14,69 @@ import {
     getMyMomentDetail, 
     getFriendsMoments, 
     getFriendMomentDetail  } from "../services/moment.service.js";
+
+
 export const handleCreateMoment = async (req, res, next) => {
-/*
-    #swagger.tags = ['Moments']
-    #swagger.summary = 'Moment 생성 API'
-    #swagger.description = '새로운 Moment를 생성합니다.'
-    #swagger.security = [{ "bearerAuth": [] }]
-    #swagger.requestBody = {
-        required: true,
-        content: {
-            "application/json": {
-                schema: {
-                    type: "object",
-                    properties: {
-                        title: { type: "string", example: "25년 1월7일" },
-                        status: { type: "string", enum: ["draft", "public"], example: "draft" },
-                        momentContents: {
-                            type: "array",
-                            items: {
-                                oneOf: [
-                                    {
-                                        type: "object",
-                                        properties: {
-                                            sortOrder: { type: "integer", example: 1 },
-                                            content: { type: "string", example: "오늘 하루 열심히 공부했어요!" },
-                                            url: { type: "string", nullable: true, example: "https://image1.com/image1.jpg" }
+    /*
+        #swagger.tags = ['Moments']
+        #swagger.summary = 'Moment 생성 API'
+        #swagger.description = '새로운 Moment를 생성합니다.'
+        #swagger.security = [{ "bearerAuth": [] }]
+        #swagger.requestBody = {
+            required: true,
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            title: { type: "string", example: "25년 1월7일" },
+                            plannerId: { type: "integer", nullable: true, example: 123 },
+                            momentContents: {
+                                type: "array",
+                                items: {
+                                    oneOf: [
+                                        {
+                                            type: "object",
+                                            properties: {
+                                                sortOrder: { type: "integer", example: 1 },
+                                                content: { type: "string", example: "오늘 하루 열심히 공부했어요!" },
+                                                url: { type: "string", nullable: true, example: "https://image1.com/image1.jpg" }
+                                            }
+                                        },
+                                        {
+                                            type: "object",
+                                            properties: {
+                                                sortOrder: { type: "integer", example: 2 },
+                                                content: { type: "string", example: "카페에서 공부 중" },
+                                                url: { type: "string", nullable: true, example: "https://image2.com/image2.jpg" }
+                                            }
+                                        },
+                                        {
+                                            type: "object",
+                                            properties: {
+                                                sortOrder: { type: "integer", example: 3 },
+                                                content: { type: "string", example: "독서실에서 마지막 정리!" },
+                                                url: { type: "string", nullable: true, example: "https://image3.com/image3.jpg" }
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                }
                             }
-                        }
-                    },
-                    required: ["title", "status", "momentContents"]
+                        },
+                        required: ["title", "momentContents"]
+                    }
                 }
             }
         }
-    }
-*/
+    */
 
     try {
-        console.log("moment 생성 요청");
         const momentData = await momentCreate({
             ...bodyToCreateMoment(req.body),
-            userId: req.user.id,
-            plannerId: req.body.plannerId || null
+            userId: req.user.id
         });
 
-        res.status(200).json({
+        res.status(StatusCodes.CREATED).json({
             resultType: "SUCCESS",
             error: null,
             success: {
@@ -147,33 +163,6 @@ export const handleDeleteMoment = async (req, res, next) => {
             required: true,
             description: "삭제할 Moment의 ID",
             schema: { type: "integer", example: 123 }
-        }
-
-        #swagger.responses[200] = {
-            description: 'Moment 삭제 성공',
-            content: {
-                "application/json": {
-                    schema: {
-                        type: "object",
-                        properties: {
-                            resultType: { type: "string", example: "SUCCESS", description: "결과 타입" },
-                            error: { type: "object", nullable: true, example: null, description: "에러 정보 (없을 경우 null)" },
-                            success: {
-                                type: "object",
-                                properties: {
-                                    message: { type: "string", example: "Moment가 성공적으로 삭제되었습니다.", description: "성공 메시지" },
-                                    data: {
-                                        type: "object",
-                                        properties: {
-                                            deletedMomentId: { type: "integer", example: 123, description: "삭제된 Moment ID" }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
     */
 
@@ -506,5 +495,3 @@ export const handleGetFriendMomentDetail = async (req, res, next) => {
         next(error);
     }
 };
-
-

--- a/src/dtos/moment.dto.js
+++ b/src/dtos/moment.dto.js
@@ -1,34 +1,38 @@
 export const bodyToCreateMoment = (body) => {
     if (!body) {
-        throw new Error("요청 본문이 비어 있습니다."); // ✅ body 자체가 없는 경우
+        throw new Error("요청 body값이 없습니다."); // body값이 없는 경우
     }
 
-    if (!body.status) {
-        throw new Error("저장할 상태를 지정해주세요."); // ✅ status가 없는 경우
+    if (!Array.isArray(body.momentContents)) {
+        throw new Error("momentContents는 배열이어야 합니다.");
     }
 
-    const momentContents = Array.isArray(body.momentContents) ? body.momentContents : [];
+    const momentContents = body.momentContents;
 
-    if (body.status === "public") {
-        if (!body.title) {
-            throw new Error("공개 상태에서는 제목이 필수입니다.");
-        }
-        if (momentContents.length === 0) {
-            throw new Error("공개 상태에서는 최소 하나 이상의 페이지가 필요합니다.");
-        }
-        if (momentContents.some(content => !content.content)) {
-            throw new Error("공개 상태에서는 모든 페이지에 content 값이 포함되어야 합니다.");
-        }
+
+    if (!body.title) {
+        throw new Error("제목을 작성해주세요.");
     }
+    if (momentContents.length === 0) {
+        throw new Error("최소 하나의 페이지가 존재해야합니다.");
+    }
+    if (momentContents.some(content => content.content === undefined || content.content === null || content.content.trim() === '')) {
+        throw new Error("모든 페이지에 빈 내용이 포함될 수 없습니다.");
+    }
+
+    const sortOrders = momentContents.map(content => content.sortOrder);
+    if (new Set(sortOrders).size !== sortOrders.length) {
+        throw new Error("sortOrder 값은 중복될 수 없습니다.");
+    }
+    
 
     return {
-        title: body.title || null,
-        status: body.status,
-        plannerId: body.plannerId || null, // ✅ plannerId가 없으면 null 처리
+        title: body.title,
+        plannerId: body.plannerId ?? null, // plannerId가 없으면 null 처리
         momentContents: momentContents.map(content => ({
             sortOrder: content.sortOrder,
-            content: content.content ?? null,
-            url: content.url || null
+            content: content.content,
+            url: content.url ?? null
         }))
     };
 };
@@ -40,14 +44,13 @@ export const responseFromCreateMoment = (moment) => {
         id: moment.id,
         userId: moment.userId,
         title: moment.title,
-        status: moment.status,
-        plannerId: moment.plannerId || null,
+        plannerId: moment.plannerId ?? null,
         createdAt: moment.createdAt,
         updatedAt: moment.updatedAt,
         momentContents: moment.momentContents.map(content => ({
             sortOrder: content.sortOrder,
             content: content.content,
-            url: content.url,
+            url: content.url ?? null,
         }))
     };
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -141,3 +141,74 @@ export class ContentTooLongError extends Error{
     this.data = data;
   }
 }
+
+// moment생성 에러처리
+
+// 서버 오류
+export class MomentServerError extends Error {
+  errorCode = "M001";
+
+  constructor(reason = "서버 오류가 발생했습니다.", data = {}) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+// 유효하지 않은 plannerId
+export class InvalidPlannerIdError extends Error {
+  errorCode = "M002";
+
+  constructor(data) {
+    const reason = "유효하지 않은 plannerId입니다.";
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+// 제목 누락
+export class MissingTitleError extends Error {
+  errorCode = "M003";
+
+  constructor() {
+    const reason = "제목을 작성해주세요.";
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+// 페이지 누락
+export class MissingMomentContentError extends Error {
+  errorCode = "M004";
+
+  constructor() {
+    const reason = "최소 하나의 페이지가 존재해야 합니다.";
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+// 페이지 내용 누락
+export class MissingContentInPageError extends Error {
+  errorCode = "M005";
+
+  constructor(data) {
+    const reason = "모든 페이지에 빈 내용이 포함될 수 없습니다.";
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+// 중복된 sortOrder
+export class DuplicateSortOrderError extends Error {
+  errorCode = "M006";
+
+  constructor(data) {
+    const reason = "sortOrder 값은 중복될 수 없습니다.";
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import { handleEditUser, handleCheckNickname, handleMyProfile, handleUserProfile
 import { body, query, param } from "express-validator";
 import { handleDisplayPlanner, handleDeletePlanner } from "./controllers/planner.controller.js";
 import { userDeleteScheduler } from "./scheduler.js";
-import { handleCreateMoment, handleUpdateMoment, handleDeleteMoment, handleGetMyMoments, handleGetMyMomentDetail, handleGetFriendsMoments, handleGetFriendMomentDetail} from "./controllers/moment.controller.js";
 import { upload } from "./multer.js";
 import { authenticateJWT } from "./auth.config.js";
 import { handleNaverTokenLogin, handleKakaoTokenLogin, handleGoogleTokenLogin, handleRefreshToken } from "./auth.config.js";
@@ -74,7 +73,8 @@ app.get("/openapi.json", async (req, res, next) => {
       title: "PLANALOG",
       description: "PLANALOG 테스트 문서입니다.",
     },
-    host: "15.164.83.14:3000",
+    host: "localhost:3000",
+
     components: {
       securitySchemes: {
         bearerAuth: {
@@ -161,13 +161,24 @@ app.delete("/planners/:plannerId", [
 ], authenticateJWT, handleDeletePlanner);
 
 
+import { 
+  handleCreateMoment, 
+  handleUpdateMoment, 
+  handleDeleteMoment, 
+  handleGetMyMoments, 
+  handleGetMyMomentDetail, 
+  handleGetFriendsMoments, 
+  handleGetFriendMomentDetail} from "./controllers/moment.controller.js";
+
 app.post("/moments", authenticateJWT, handleCreateMoment); //모먼트 생성
 app.patch("/moments/:momentId", authenticateJWT, handleUpdateMoment); //모먼트 수정
 app.delete("/moments/:momentId", authenticateJWT, handleDeleteMoment); //모먼트 삭제
-app.get("mypage/moments/mine", authenticateJWT, handleGetMyMoments); //마이페이지에서 나의 moment게시글 목록 조회
-app.get("mypage/moments/:momentId", authenticateJWT, handleGetMyMomentDetail); //마이페이지에서 나의  특정 moment게시물 조회 
+app.get("/mypage/moments", authenticateJWT, handleGetMyMoments); //마이페이지에서 나의 moment게시글 목록 조회
+app.get("/mypage/moments/:momentId", authenticateJWT, handleGetMyMomentDetail); //마이페이지에서 나의  특정 moment게시물 조회 
 app.get("/friends/:friendId/moments", authenticateJWT, handleGetFriendsMoments) //친구페이지 moment게시물 목록 조회
-app.get("/friends/:friendId/moments/momentId", authenticateJWT, handleGetFriendMomentDetail) //친구페이지 특정 moment게시물 조회
+app.get("/friends/:friendId/moments/momentId", authenticateJWT, handleGetFriendMomentDetail); //친구페이지 특정 moment게시물 조회
+
+
 
 //회원 탈퇴 
 app.delete("/users", authenticateJWT, handleDeleteUser)

--- a/src/test.js
+++ b/src/test.js
@@ -89,3 +89,5 @@ export const testUserMiddleware = async (req, res, next) => {
         return res.status(500).json({ message: "테스트 유저 생성 실패", error: error.message });
     }
 }
+
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

* prisma의 status를 public과 draft로 나누지 않기로 해서 수정했습니다.
* 기존 코드를 테스팅했을 때 momentContent값이 빈 배열로 출력되는 에러의 로직을 수정했습니다.
* moment생성의 대한 에러를 errors.js에 정의하고 moment.sevice.js에서 사용하도록 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?