### PR TITLE
Feature: 할일 다중생성 api 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="aa057fb3-95e3-4ca5-9656-3792bd70e880" name="변경" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/prisma/schema.prisma" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/schema.prisma" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/controllers/task.controller.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/task.controller.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/dtos/task.dto.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/dtos/task.dto.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/repositories/task.repository.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/repositories/task.repository.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/task.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/task.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/services/task.service.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/services/task.service.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/category.controller.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/category.controller.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/repositories/category.repository.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/repositories/category.repository.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/category.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/category.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/services/category.service.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/services/category.service.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,12 @@
   <component name="ChangeListManager">
     <list default="true" id="aa057fb3-95e3-4ca5-9656-3792bd70e880" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/prisma/schema.prisma" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/schema.prisma" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/task.controller.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/task.controller.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/dtos/task.dto.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/dtos/task.dto.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/repositories/task.repository.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/repositories/task.repository.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/task.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/task.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/services/task.service.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/services/task.service.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="aa057fb3-95e3-4ca5-9656-3792bd70e880" name="변경" comment="">
-      <change beforePath="$PROJECT_DIR$/src/controllers/category.controller.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/category.controller.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/services/category.service.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/services/category.service.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="aa057fb3-95e3-4ca5-9656-3792bd70e880" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/src/controllers/category.controller.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/category.controller.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/repositories/category.repository.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/repositories/category.repository.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/category.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/category.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/services/category.service.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/services/category.service.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Planner {
   Moment Moment[]
 
   @@index([userId], map: "userId")
+  @@unique([userId, plannerDate], map: "unique_user_planner_date") // Composite Unique Constraint
   @@map("planner")
 }
 

--- a/src/controllers/category.controller.js
+++ b/src/controllers/category.controller.js
@@ -89,6 +89,7 @@ export const handleCreateCategoryBulk = async (req, res, next) => {
         if (!req.user || !req.user.id) {
             throw new Error("사용자 인증 정보가 누락되었습니다.");
         }
+        // id BigInt 로 변환후 
         const createdCategories = await createCategoryBulk({ userId, names }); // 서비스 호출
         // 성공 응답
         res.success(createdCategories); 

--- a/src/controllers/category.controller.js
+++ b/src/controllers/category.controller.js
@@ -2,7 +2,8 @@ import {createCategory,
         updateCategory,
         getCategoriesByUser,
         deleteCategoryService,
-        createTaskCategory
+        createTaskCategory,
+        createCategoryBulk
 } from '../services/category.service.js'
 import { createTaskDto } from '../dtos/task.dto.js';
 import { deleteCategoryRepository } from '../repositories/category.repository.js';
@@ -23,7 +24,7 @@ export const handleCreateCategory = async (req, res, next) => {
                         properties: {
                             name: { 
                                 type: "string", 
-                                example: "Work", 
+                                example: "Personal", 
                                 description: "카테고리 이름" 
                             }
                         },
@@ -35,7 +36,7 @@ export const handleCreateCategory = async (req, res, next) => {
         */
     try {
         //세션에서 userId 가져오기 
-        const userId = req.user.id;
+        const user_id = req.user.id;
         const name = req.body.name;
         console.log("Data received to controller(userId, name):", userId, name);
 
@@ -44,17 +45,60 @@ export const handleCreateCategory = async (req, res, next) => {
             throw new Error("사용자 인증 정보가 누락되었습니다.");
         }
 
-        const createdTaskCategory = await createCategory({ userId, name }); // 서비스 호출
+        const createdTaskCategory = await createCategory({ user_id, name }); // 서비스 호출
         res.success(createdTaskCategory); // 성공 응답
     } catch (error) {
         next(error); // 전역 오류 처리 미들웨어로 전달
     }
 };
 
-
+// 카테고리 한번에 여러개 생성
+export const handleCreateCategoryBulk = async (req, res, next) => {
+    /*
+    #swagger.tags = ['Categories']
+    #swagger.summary = '카테고리 다중 생성 API'
+    #swagger.description = '여러 카테고리를를 한 번에 생성하는 API입니다.'
+    #swagger.security = [{
+        "bearerAuth": []
+    }]
+    #swagger.requestBody = {
+        required: true,
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "array",
+                            description: "카테고리 리스트",
+                            example: ["운동", "공부", "알바"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+    */
+   try {
+        // 인증 미들웨어에서 설정된 사용자 ID
+        const userId = req.user.id; 
+        // req.body에서 카테고리 이름 배열 추출 
+        
+        const name = req.body;
+        // userId 있는지 확인 
+        if (!req.user || !req.user.id) {
+            throw new Error("사용자 인증 정보가 누락되었습니다.");
+        }
+        const createdCategories = await createCategoryBulk({ userId, name }); // 서비스 호출
+        // 성공 응답
+        res.success(createdCategories); 
+   } catch (error) {
+       next(error); 
+   }
+}
 // 카테고리 수정
 export const handleUpdateCategory = async (req, res, next) => {
-/*
+    /*
     #swagger.tags = ['Categories']
     #swagger.summary = '카테고리 수정 API'
     #swagger.security = [{

--- a/src/controllers/category.controller.js
+++ b/src/controllers/category.controller.js
@@ -68,7 +68,7 @@ export const handleCreateCategoryBulk = async (req, res, next) => {
                 schema: {
                     type: "object",
                     properties: {
-                        name: {
+                        names: {
                             type: "array",
                             description: "카테고리 리스트",
                             example: ["운동", "공부", "알바"]
@@ -82,14 +82,14 @@ export const handleCreateCategoryBulk = async (req, res, next) => {
    try {
         // 인증 미들웨어에서 설정된 사용자 ID
         const userId = req.user.id; 
-        // req.body에서 카테고리 이름 배열 추출 
+        const names = req.body.names;
         
-        const name = req.body;
+        
         // userId 있는지 확인 
         if (!req.user || !req.user.id) {
             throw new Error("사용자 인증 정보가 누락되었습니다.");
         }
-        const createdCategories = await createCategoryBulk({ userId, name }); // 서비스 호출
+        const createdCategories = await createCategoryBulk({ userId, names }); // 서비스 호출
         // 성공 응답
         res.success(createdCategories); 
    } catch (error) {

--- a/src/controllers/task.controller.js
+++ b/src/controllers/task.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
-import { createTask } from "../services/task.service.js";
-import { createTaskDto, getTaskDto, responseFromToggledTask, updateTaskDto } from "../dtos/task.dto.js";
+import { createTask,createTaskBulk} from "../services/task.service.js";
+import { createTaskBulkDto, createTaskDto, getTaskDto, responseFromToggledTask, updateTaskDto } from "../dtos/task.dto.js";
 import { updateTask, getTask, deleteTask } from "../services/task.service.js";
 import { toggleTaskCompletion } from "../services/task.service.js";
 import { findTaskWithPlanner } from "../repositories/task.repository.js";
@@ -66,6 +66,56 @@ export const handleCreateTask = async (req, res, next) => {
     }
 }
 
+export const handleCreateTaskBulk = async (req, res, next) => {
+    /*
+    #swagger.tags = ['Tasks']
+    #swagger.summary = '할일 다중 생성 API'
+    #swagger.description = '여러 할일을 한 번에 생성하는 API입니다.'
+    #swagger.security = [{
+        "bearerAuth": []
+    }]
+    #swagger.requestBody = {
+        required: true,
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        title: {
+                            type: "array",
+                            description: "할일 제목 리스트",
+                            example: ["오늘 할일 1", "오늘 할일 2", "오늘 할일 3"]
+                        },
+                        planner_date: {
+                            type: "string",
+                            format: "date",
+                            description: "할일 일정 날짜 (YYYY-MM-DD)",
+                            example: "2025-01-10"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    */
+   try {
+        const user_id = req.user.id;
+        if (!user_id) {
+            throw new Error("사용자 인증이 필요합니다.");
+        }
+        //dto로 검증 
+        const validTaskData = await createTaskBulkDto(req.body);
+        
+        console.log(validTaskData);
+        //여러개 생성 
+        const newTasks= await createTaskBulk (validTaskData, user_id);
+
+        res.success(newTasks);
+   } catch (error) {
+        next(error);
+   }
+
+}
 export const handleUpdateTask = async (req, res, next) => {
     /*
         #swagger.tags = ['Tasks']

--- a/src/dtos/task.dto.js
+++ b/src/dtos/task.dto.js
@@ -9,7 +9,8 @@ export const createTaskDto = (body) => {
     if (!body.planner_date) {
         throw new Error("Planner date is required");
     }
-    const planner_date = new Date(body.planner_date)
+    const planner_date = new Date(body.planner_date + "T00:00:00.000Z"); // ✅ 초 단위까지 동일하게 변환
+
     // 3. 데이터 반환 
     return {
         title: body.title,
@@ -17,6 +18,25 @@ export const createTaskDto = (body) => {
     };
 
 }
+export const createTaskBulkDto = (body) => {
+    // body 는 배열 형태의 제목들(String)과 String 형태의 날짜
+    // 1. 배열 검증 (title이 배열인지 확인)
+    if (!body.title || !Array.isArray(body.title) || body.title.length === 0) {
+        throw new Error("할일(title)은 배열 형태로 전달되어야 합니다.");
+    }
+
+    // 2. planner_date가 문자열인지 확인
+    if (!body.planner_date || typeof body.planner_date !== "string") {
+        throw new Error("planner_date는 문자열이어야 합니다.");
+    }
+
+    // 3. DTO 변환 (각각 개별의 할 일 객체로 변환 할일 => {할일, 날짜})
+    return body.title.map(title => ({
+        title: title,
+        planner_date: new Date(body.planner_date + "T00:00:00.000Z") // ✅ 초 단위까지 동일하게 변환
+        // 공통된 날짜 적용
+    }));
+};
 export const updateTaskDto = (task_id, body) => {
     // task_id 숫자인지 확인 
     if (isNaN(task_id)) {

--- a/src/repositories/category.repository.js
+++ b/src/repositories/category.repository.js
@@ -11,7 +11,6 @@ export const createCategoryRepository = async ({ userId, name }) => {
         });
         return createdCategory;
     } catch (error) {
-        console.error("Error creating task category:", error);
         throw new Error("Database error: Failed to create task category");
     }
 };
@@ -29,7 +28,6 @@ export const updateCategoryRepository = async (id, name) => {
         });
         return updatedCategory;
     } catch (error) {
-        console.error("Error updating task category:", error);
         throw new Error("Database error: Failed to update task category");
     }
 };
@@ -47,7 +45,6 @@ export const getAllCategoriesRepository = async (userId) => {
         });
         return categories;
     } catch (error) {
-        console.error("Error fetching task categories:", error);
         throw new Error("Database error: Failed to fetch task categories");
     }
 };
@@ -66,7 +63,6 @@ export const deleteCategoryRepository = async (ids) => {
 
         return deletedCategory;
     } catch (error) {
-        console.error("Error deleting task category:", error);
         throw new Error("Database error: Failed to delete task category");
     }
 };
@@ -84,7 +80,6 @@ export const createTaskCategoryRepository = async ({ task_category_id, title, pl
 
         return newTaskCategory;
     } catch (error) {
-        console.error("Error creating task category:", error);
         throw new Error("Database error occurred while creating task category.");
     }
 };

--- a/src/repositories/category.repository.js
+++ b/src/repositories/category.repository.js
@@ -1,7 +1,17 @@
 import { prisma } from '../db.config.js';
 
 export const createCategoryRepository = async ({ userId, name }) => {
+    
     try {
+        //중복 값 확인 
+
+        const existingCategory = await prisma.taskCategory.findFirst({
+            where: {name: name, userId: BigInt(userId)}
+        })
+        if (existingCategory) {
+            // 중복된 카테고리가 이미 존재하면 null 반환환
+            return null;
+        }
         // 카테고리 생성
         const createdCategory = await prisma.taskCategory.create({
             data: {

--- a/src/repositories/task.repository.js
+++ b/src/repositories/task.repository.js
@@ -5,14 +5,16 @@ import { getPlannerWithTasks } from "./planner.repository.js"; // 기존 코드 
 export const addTask = async (data) => {
     // Prisma를 사용하여 DB에 새로운 Task 생성
     // task_category_id가 있으면 BigInt 변환, 없으면 null
+    console.log("data 확인", data);
     const category_id = data.task_category_id ? BigInt(data.task_category_id) : null;
 
     if (data.category_id) {
         category_id = data.category_id;
     }
+    
     // 해당 날짜에 플래너가 있는지 조회
     // 해당 날짜의 플래너 확인 (기존 코드 활용)
-    let planner = await getPlannerWithTasks(data.userId, data.planner_date);
+    let planner = await getPlannerWithTasks(data.user_id, data.planner_date);
     console.log("planner 날짜로 확인", planner);
 
     // 플래너가 있는지 확인하고 없으면 플래너 생성. 
@@ -23,8 +25,8 @@ export const addTask = async (data) => {
         console.log("Planner not found. Creating a new planner...");
         planner = await prisma.planner.create({
             data: {
-                plannerDate: new Date(data.planner_date),
-                userId: data.userId,
+                plannerDate: data.planner_date,
+                userId: data.user_id,
                 isCompleted: false,
             },
         });

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,6 +1,6 @@
 import express from "express";
 import {handleCreateCategory, handleUpdateCategory, handleViewCategory , handleDeleteCategory,
-    handleCreateTaskCategory
+    handleCreateTaskCategory, handleCreateCategoryBulk
 } from "../controllers/category.controller.js";
 
 
@@ -8,6 +8,7 @@ const router = express.Router();
 
 router.post("/", handleCreateCategory);
 
+router.post("/bulk/", handleCreateCategoryBulk);
 
 router.post("/:task_category_id/tasks", handleCreateTaskCategory);
 

--- a/src/routes/task.js
+++ b/src/routes/task.js
@@ -1,10 +1,11 @@
 import express from "express";
 import { handleCreateTask } from "../controllers/task.controller.js";
 import { handleUpdateTask } from "../controllers/task.controller.js";
-import { handleGetTask, handleDeleteTask, handleToggleCompletion } from "../controllers/task.controller.js";
+import { handleGetTask, handleDeleteTask, handleToggleCompletion, handleCreateTaskBulk } from "../controllers/task.controller.js";
 const router = express.Router();
 
 router.post("/", handleCreateTask);
+router.post("/bulk", handleCreateTaskBulk);
 
 router.patch("/:task_id", handleUpdateTask);
 

--- a/src/services/category.service.js
+++ b/src/services/category.service.js
@@ -21,18 +21,13 @@ export const createCategory = async ({ userId, name }) => {
     }
 };
 // 카테고리 여러개 생성
-export const createCategoryBulk = async ({userId, name}) => {
-    console.log(
-        "request received to Service and userId",
-        userId,
-        name
-    );
-    console.log("type of name", typeof name);
+export const createCategoryBulk = async ({userId, names}) => {
+    // 배열 생성 (추가된 카테고리) 
     const addedCategories = [];
     try {
         // 반복문으로 categories의 각 요소를 하나씩 받아서 카테고리 생성
-        for (const category of name.name) {
-            const newCategory = await createCategoryRepository({ userId, name: category });
+        for (const name of names) {
+            const newCategory = await createCategoryRepository({ userId, name: name });
             addedCategories.push(newCategory);
         }
 

--- a/src/services/category.service.js
+++ b/src/services/category.service.js
@@ -23,15 +23,26 @@ export const createCategory = async ({ userId, name }) => {
 // 카테고리 여러개 생성
 export const createCategoryBulk = async ({userId, names}) => {
     // 배열 생성 (추가된 카테고리) 
-    const addedCategories = [];
+    const success = [];
+    const failed = [];
     try {
         // 반복문으로 categories의 각 요소를 하나씩 받아서 카테고리 생성
         for (const name of names) {
             const newCategory = await createCategoryRepository({ userId, name: name });
-            addedCategories.push(newCategory);
+            // 중복 카테고리가 아니면 추가
+            if (newCategory) {
+                success.push(newCategory);
+            } else {
+                failed.push({ name, reason: "중복된 카테고리" });
+            }
         }
 
-        return addedCategories;
+        return {
+            resultType: success.length === 0 ? "FAIL" : failed.length > 0 ? "PARTIAL_SUCCESS" : "SUCCESS",
+            error: null,
+            success,
+            failed
+        };
     } catch (error) {
         throw error;
     }

--- a/src/services/category.service.js
+++ b/src/services/category.service.js
@@ -20,6 +20,27 @@ export const createCategory = async ({ userId, name }) => {
         throw new Error("Failed to create task category");
     }
 };
+// 카테고리 여러개 생성
+export const createCategoryBulk = async ({userId, name}) => {
+    console.log(
+        "request received to Service and userId",
+        userId,
+        name
+    );
+    console.log("type of name", typeof name);
+    const addedCategories = [];
+    try {
+        // 반복문으로 categories의 각 요소를 하나씩 받아서 카테고리 생성
+        for (const category of name.name) {
+            const newCategory = await createCategoryRepository({ userId, name: category });
+            addedCategories.push(newCategory);
+        }
+
+        return addedCategories;
+    } catch (error) {
+        throw error;
+    }
+};
 // 카테고리 수정
 export const updateCategory = async (id, name) => {
     try {

--- a/src/services/task.service.js
+++ b/src/services/task.service.js
@@ -26,6 +26,22 @@ export const createTask = async (taskData) => {
 
 
 }
+export const createTaskBulk = async (taskData, user_id) => {
+  console.log("request received to Service and userId", taskData, user_id);
+  console.log("type of taskData", typeof taskData);
+  const addedTaskData = [];
+  
+  try {
+    //반복문으로 taskData의 각 요소를 하나씩 받아서 task 생성
+    for (const task of taskData) {
+      const newTask = await addTask({...task, user_id});
+      addedTaskData.push(newTask);
+    }
+    return addedTaskData;
+  } catch (error) {
+    throw error;
+  }
+};
 
 export const updateTask = async (taskData) => {
   // Task 수정 로직 
@@ -40,7 +56,7 @@ export const updateTask = async (taskData) => {
     throw error;
   }
 
-}
+};
 export const deleteTask = async (ids, userId) => {
   try {
     // 권한 확인 및 삭제 대상 조회


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
- 할일 다중생성 기능 추가했습니다. (배열로 된 값을 입력받아 반복문 돌려서 할일을 생성 했습니다) 
- 기존에 동일한 날짜에 동일한 유저가 여러개의 planner를 가질 수 있었습니다. 각 날짜별로 유저가 하나의 planner 만 가질 수 있게 user_id 와 planner_date를 플래너 테이블에 복합키로 작성하여 중복을 방지했습니다.  


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 중복 방지하기 위해 프리즈마 스키마 변경했는데 확인 부탁드립니다. 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?